### PR TITLE
fix(#213): make inline codeblock text pink in all modes

### DIFF
--- a/src/scss/obsidian/code-blocks.scss
+++ b/src/scss/obsidian/code-blocks.scss
@@ -23,6 +23,10 @@
 
 body {
   --code-normal-inline: var(--pink);
+
+  .cm-inline-code {
+    --code-normal: var(--pink);
+  }
 }
 
 .markdown-rendered code:not(pre code) {


### PR DESCRIPTION
Fixes: #213